### PR TITLE
Deprecated `followdpi` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ Open http://localhost:9001/demo/index.html
 
 ## Usage
 ```html
-<dpi-aware-image followdpi src='/demo/dist/icon.png'></dpi-aware-image>
+<style>
+  /* Optional */
+  dpi-aware-image {
+    display: inline-block;
+    --max-width: 100%;
+    --max-height: 300px;
+  }
+</style>
+
+<dpi-aware-image src='/demo/dist/icon.png'></dpi-aware-image>
 ```
 
 ## Demos

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -12,7 +12,7 @@
     </div>
     <div>
       <h2><pre>&lt;dpi-aware-image&gt;</pre></h2>
-      <dpi-aware-image followdpi></dpi-aware-image>
+      <dpi-aware-image></dpi-aware-image>
     </div>
     <div class='img default'>
       <h2><pre>&lt;img&gt;</pre></h2>

--- a/demo/dist/demo.js
+++ b/demo/dist/demo.js
@@ -74,11 +74,6 @@ class DpiAwareImage extends HTMLElement {
         {
           if (!newVal) return;
           this.removeOlder();
-
-          if (this.getAttribute('followdpi') === null) {
-            return this.renderImg(newVal);
-          }
-
           const {
             width,
             height,

--- a/demo/gyazo.html
+++ b/demo/gyazo.html
@@ -20,7 +20,7 @@
         </a> or Gyazo for macOS (Mojave).
       </p>
       <dpi-aware-image
-        followdpi src='https://gyakky.herokuapp.com/gyazo/raw/8120a5842dfe69bdc8dcc0c67c788d4f'>
+        src='https://gyakky.herokuapp.com/gyazo/raw/8120a5842dfe69bdc8dcc0c67c788d4f'>
       </dpi-aware-image>
     </div>
     <div class='img default'>

--- a/demo/index.html
+++ b/demo/index.html
@@ -23,26 +23,23 @@
     <h1>dpi-aware-image!</h1>
 
     <h2>dpi=72</h2>
-    <dpi-aware-image src='../static/mac.png' followdpi></dpi-aware-image>
+    <dpi-aware-image src='../static/mac.png'></dpi-aware-image>
     <dpi-aware-image src='../static/mac_2.png'></dpi-aware-image>
 
     <h2>dpi=144</h2>
+    <dpi-aware-image src='../static/mac_retina.png'></dpi-aware-image>
+    <br />
+    <dpi-aware-image src='../static/mac_retina_2.png'></dpi-aware-image>
+    <br />
     <dpi-aware-image src='./dist/icon.png'></dpi-aware-image>
-
-    <h2>dpi=144 (followdpi)</h2>
-    <dpi-aware-image src='../static/mac_retina.png' followdpi></dpi-aware-image>
-    <br />
-    <dpi-aware-image src='../static/mac_retina_2.png' followdpi></dpi-aware-image>
-    <br />
-    <dpi-aware-image followdpi src='./dist/icon.png'></dpi-aware-image>
 
     <h3>max-width=100%; max-height=300px;</h3>
     <dpi-aware-image
-      followdpi class='image'
+      class='image'
       src='../static/mac_retina_2.png'></dpi-aware-image>
     <a href='https://example.com' target='_blank'>
       <dpi-aware-image
-        followdpi class='image'
+        class='image'
         src='https://gyakky.herokuapp.com/gyazo/raw/8120a5842dfe69bdc8dcc0c67c788d4f'></dpi-aware-image>
     </a>
     <br />
@@ -50,7 +47,7 @@
     <div>
       <span>text1</span>
       <dpi-aware-image
-        followdpi class='image middle'
+        class='image middle'
         src='https://gyakky.herokuapp.com/gyazo/raw/13c696cd1e707a04feb8f622205ace69'></dpi-aware-image>
       <span>text2</span>
     </div>

--- a/src/index.js
+++ b/src/index.js
@@ -33,9 +33,6 @@ export class DpiAwareImage extends HTMLElement {
       case 'src': {
         if (!newVal) return
         this.removeOlder()
-        if (this.getAttribute('followdpi') === null) {
-          return this.renderImg(newVal)
-        }
         const {width, height, dpi} = await this.getImageSize(newVal)
         if (!width || !height || !dpi) {
           return this.renderImg(newVal)


### PR DESCRIPTION
常にdpiを考慮したサイズで画像を表示するCustomElementとして振る舞う

http://localhost:9001/ 内の画像を適切なサイズで表示できればOK